### PR TITLE
fix #7 - improve read system info to collect more data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# 2.4.1 - UNRELEASED
+# 2.5.0 - UNRELEASED
+
+## Changed
+
+[system info] - improve command to collect more information ([#7](https://github.com/eove/flow-analyzer-com/issues/7))
 
 # 2.4.0 - 2021-11-03
 

--- a/packages/flow-analyzer-com-communicator/lib/domain/DeviceTypes.ts
+++ b/packages/flow-analyzer-com-communicator/lib/domain/DeviceTypes.ts
@@ -1,4 +1,11 @@
 export enum DeviceTypes {
+  INVALID = 'invalid',
   CITREX_H4 = 'h4',
+  CITREX_H5 = 'h5',
+  CITREX_H3 = 'h3',
   PF300 = 'pf300',
+  PF300_PRO = 'pf300-Pro',
+  VT305 = 'vt305',
+  FLOW_METER_F1 = 'f1',
+  FLOW_METER_F2 = 'f2',
 }

--- a/packages/flow-analyzer-com-communicator/lib/domain/system/createReadSystemInfosHandler.spec.ts
+++ b/packages/flow-analyzer-com-communicator/lib/domain/system/createReadSystemInfosHandler.spec.ts
@@ -27,6 +27,27 @@ describe('Read system infos handler', () => {
     runCommand.onCall(4).resolves({
       value: '898',
     });
+    runCommand.onCall(5).resolves({
+      value: '26',
+    });
+    runCommand.onCall(6).resolves({
+      value: '12',
+    });
+    runCommand.onCall(7).resolves({
+      value: '23',
+    });
+    runCommand.onCall(8).resolves({
+      value: '26',
+    });
+    runCommand.onCall(9).resolves({
+      value: '12',
+    });
+    runCommand.onCall(10).resolves({
+      value: '24',
+    });
+    runCommand.onCall(11).resolves({
+      value: '2',
+    });
 
     const buildCommand = stub().returns({ id: 3, value: 1, raw: 'RRRRRRR' });
     const debug = (msg: any) => msg;
@@ -44,11 +65,15 @@ describe('Read system infos handler', () => {
       type: 'A_TYPE',
     });
 
-    expect(runCommand.callCount).toEqual(5);
+    expect(runCommand.callCount).toEqual(12);
     expect(result).toEqual({
       hardwareVersion: '6',
       serialNumber: '898',
       softwareVersion: '2.3.001',
+      deviceType: 'vt305',
+
+      lastCalibrationDate: '23-12-26',
+      nextCalibrationDate: '24-12-26',
     });
   });
 });

--- a/packages/flow-analyzer-com-communicator/lib/domain/system/createReadSystemInfosHandler.spec.ts
+++ b/packages/flow-analyzer-com-communicator/lib/domain/system/createReadSystemInfosHandler.spec.ts
@@ -63,6 +63,14 @@ describe('Read system infos handler', () => {
   it('should run many commands before returning', async () => {
     const result = await handler.handle({
       type: 'A_TYPE',
+      payload: {
+        deviceType: true,
+        hardwareVersion: true,
+        softwareVersion: true,
+        serialNumber: true,
+        lastCalibrationDate: true,
+        nextCalibrationDate: true,
+      },
     });
 
     expect(runCommand.callCount).toEqual(12);
@@ -71,7 +79,6 @@ describe('Read system infos handler', () => {
       serialNumber: '898',
       softwareVersion: '2.3.001',
       deviceType: 'vt305',
-
       lastCalibrationDate: '23-12-26',
       nextCalibrationDate: '24-12-26',
     });

--- a/packages/flow-analyzer-com-communicator/lib/domain/system/createReadSystemInfosHandler.ts
+++ b/packages/flow-analyzer-com-communicator/lib/domain/system/createReadSystemInfosHandler.ts
@@ -1,9 +1,13 @@
+import * as _ from 'lodash';
 import {
   DomainCommand,
   DomainCommandHandler,
   DomainCommandHandlerFactoryDependencies,
 } from '../DomainTypes';
+import { makeGetDeviceType } from './makeGetDeviceType';
 import { makeGetHardwareVersion } from './makeGetHardwareVersion';
+import { makeGetLastCalibrationDate } from './makeGetLastCalibrationDate';
+import { makeGetNextCalibrationDate } from './makeGetNextCalibrationDate';
 import { makeGetSerialNumber } from './makeGetSerialNumber';
 import { makeGetSoftwareVersion } from './makeGetSoftwareVersion';
 
@@ -15,16 +19,55 @@ export default function createReadSystemInfosHandler(
   const getSerialNumber = makeGetSerialNumber(dependencies);
   const getHardwareVersion = makeGetHardwareVersion(dependencies);
   const getSoftwareVersion = makeGetSoftwareVersion(dependencies);
+  const getLastCalibrationDate = makeGetLastCalibrationDate(dependencies);
+  const getNextCalibrationDate = makeGetNextCalibrationDate(dependencies);
+  const getDeviceType = makeGetDeviceType(dependencies);
 
   return {
     type: 'READ_SYSTEM_INFOS',
-    handle: async ({ type }: DomainCommand) => {
+    handle: async ({ type, payload }: DomainCommand) => {
       debug(`running ${type} command handler...`);
+      const {
+        deviceType,
+        hardwareVersion,
+        softwareVersion,
+        serialNumber,
+        lastCalibrationDate,
+        nextCalibrationDate,
+      } = _.defaults({}, payload, {
+        deviceType: false,
+        hardwareVersion: true,
+        softwareVersion: true,
+        serialNumber: true,
+        lastCalibrationDate: false,
+        nextCalibrationDate: false,
+      });
 
-      const hardwareVersion = await getHardwareVersion();
-      const softwareVersion = await getSoftwareVersion();
-      const serialNumber = await getSerialNumber();
-      return { hardwareVersion, softwareVersion, serialNumber };
+      const result = {};
+      if (deviceType) {
+        Object.assign(result, { deviceType: await getDeviceType() });
+      }
+      if (hardwareVersion) {
+        Object.assign(result, { hardwareVersion: await getHardwareVersion() });
+      }
+      if (softwareVersion) {
+        Object.assign(result, { softwareVersion: await getSoftwareVersion() });
+      }
+      if (serialNumber) {
+        Object.assign(result, { serialNumber: await getSerialNumber() });
+      }
+      if (lastCalibrationDate) {
+        Object.assign(result, {
+          lastCalibrationDate: await getLastCalibrationDate(),
+        });
+      }
+      if (nextCalibrationDate) {
+        Object.assign(result, {
+          nextCalibrationDate: await getNextCalibrationDate(),
+        });
+      }
+
+      return result;
     },
   };
 }

--- a/packages/flow-analyzer-com-communicator/lib/domain/system/createReadSystemInfosHandler.ts
+++ b/packages/flow-analyzer-com-communicator/lib/domain/system/createReadSystemInfosHandler.ts
@@ -44,9 +44,7 @@ export default function createReadSystemInfosHandler(
       });
 
       const result = {};
-      if (deviceType) {
-        Object.assign(result, { deviceType: await getDeviceType() });
-      }
+
       if (hardwareVersion) {
         Object.assign(result, { hardwareVersion: await getHardwareVersion() });
       }
@@ -65,6 +63,9 @@ export default function createReadSystemInfosHandler(
         Object.assign(result, {
           nextCalibrationDate: await getNextCalibrationDate(),
         });
+      }
+      if (deviceType) {
+        Object.assign(result, { deviceType: await getDeviceType() });
       }
 
       return result;

--- a/packages/flow-analyzer-com-communicator/lib/domain/system/makeGetDeviceType.ts
+++ b/packages/flow-analyzer-com-communicator/lib/domain/system/makeGetDeviceType.ts
@@ -1,0 +1,46 @@
+import { FrameType } from '../../protocol';
+import { DeviceTypes } from '../DeviceTypes';
+import { DomainCommandHandlerFactoryDependencies } from '../DomainTypes';
+
+export function makeGetDeviceType(
+  dependencies: DomainCommandHandlerFactoryDependencies
+) {
+  const { runCommand, buildCommand } = dependencies;
+
+  return async function getDeviceType(): Promise<string> {
+    try {
+      const command = buildCommand({
+        type: FrameType.READ_SYSTEM_INFO,
+        id: 12,
+      });
+      const deviceType = await runCommand(command).then(
+        (answer) => `${answer.value}`
+      );
+      return decodeDeviceType(deviceType);
+    } catch (error) {
+      return '';
+    }
+  };
+}
+
+function decodeDeviceType(value: string): string {
+  switch (value) {
+    case '1':
+      return DeviceTypes.CITREX_H4;
+    case '2':
+      return DeviceTypes.VT305;
+    case '3':
+      return DeviceTypes.CITREX_H5;
+    case '4':
+      return DeviceTypes.CITREX_H3;
+    case '5':
+      return DeviceTypes.PF300_PRO;
+    case '6':
+      return DeviceTypes.FLOW_METER_F1;
+    case '7':
+      return DeviceTypes.FLOW_METER_F2;
+
+    default:
+      return DeviceTypes.INVALID;
+  }
+}

--- a/packages/flow-analyzer-com-communicator/lib/domain/system/makeGetLastCalibrationDate.ts
+++ b/packages/flow-analyzer-com-communicator/lib/domain/system/makeGetLastCalibrationDate.ts
@@ -1,0 +1,43 @@
+import { FrameType } from '../../protocol';
+import { DomainCommandHandlerFactoryDependencies } from '../DomainTypes';
+
+export function makeGetLastCalibrationDate(
+  dependencies: DomainCommandHandlerFactoryDependencies
+) {
+  const { runCommand, buildCommand } = dependencies;
+
+  return async function getLastCalibrationDate(): Promise<string> {
+    try {
+      const day = await getLastCalibrationDay();
+      const month = await getLastCalibrationMonth();
+      const year = await getLastCalibrationYear();
+      return `${year}-${month}-${day}`;
+    } catch (error) {
+      return '';
+    }
+
+    function getLastCalibrationDay(): Promise<any> {
+      const command = buildCommand({
+        type: FrameType.READ_SYSTEM_INFO,
+        id: 5,
+      });
+      return runCommand(command).then((answer) => `${answer.value}`);
+    }
+
+    function getLastCalibrationMonth(): Promise<any> {
+      const command = buildCommand({
+        type: FrameType.READ_SYSTEM_INFO,
+        id: 6,
+      });
+      return runCommand(command).then((answer) => `${answer.value}`);
+    }
+
+    function getLastCalibrationYear(): Promise<any> {
+      const command = buildCommand({
+        type: FrameType.READ_SYSTEM_INFO,
+        id: 7,
+      });
+      return runCommand(command).then((answer) => `${answer.value}`);
+    }
+  };
+}

--- a/packages/flow-analyzer-com-communicator/lib/domain/system/makeGetNextCalibrationDate.ts
+++ b/packages/flow-analyzer-com-communicator/lib/domain/system/makeGetNextCalibrationDate.ts
@@ -1,0 +1,43 @@
+import { FrameType } from '../../protocol';
+import { DomainCommandHandlerFactoryDependencies } from '../DomainTypes';
+
+export function makeGetNextCalibrationDate(
+  dependencies: DomainCommandHandlerFactoryDependencies
+) {
+  const { runCommand, buildCommand } = dependencies;
+
+  return async function getNextCalibrationDate(): Promise<string> {
+    try {
+      const day = await getNextCalibrationDay();
+      const month = await getNextCalibrationMonth();
+      const year = await getNextCalibrationYear();
+      return `${year}-${month}-${day}`;
+    } catch (error) {
+      return '';
+    }
+
+    function getNextCalibrationDay(): Promise<any> {
+      const command = buildCommand({
+        type: FrameType.READ_SYSTEM_INFO,
+        id: 9,
+      });
+      return runCommand(command).then((answer) => `${answer.value}`);
+    }
+
+    function getNextCalibrationMonth(): Promise<any> {
+      const command = buildCommand({
+        type: FrameType.READ_SYSTEM_INFO,
+        id: 10,
+      });
+      return runCommand(command).then((answer) => `${answer.value}`);
+    }
+
+    function getNextCalibrationYear(): Promise<any> {
+      const command = buildCommand({
+        type: FrameType.READ_SYSTEM_INFO,
+        id: 11,
+      });
+      return runCommand(command).then((answer) => `${answer.value}`);
+    }
+  };
+}

--- a/packages/flow-analyzer-com-talk/lib/shell/commands/examplesCommandHandler.js
+++ b/packages/flow-analyzer-com-talk/lib/shell/commands/examplesCommandHandler.js
@@ -11,6 +11,7 @@ const HELP_MSG =
     run WRITE_SETTING \'{"name": "gazType", "value": "Air"}\'\n\
   system:\n\
     run READ_SYSTEM_INFOS\n\
+    run READ_SYSTEM_INFOS \'{"lastCalibrationDate": true}\'\n\
   execute:\n\
     run EXEC_SET_RS232_ECHO \'{"echoOn": true}\'\n\
   \n';


### PR DESCRIPTION
A payload can be provided to read system info to collect data.

✅ tested on a pf300.

Here's the output:

```
hardwareVersion:     6
softwareVersion:     5.1.1
serialNumber:        5310
lastCalibrationDate: 2022-10-28
```